### PR TITLE
Added back old base url jvm env arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The primary goals of this project are to...
 - Utilize the power of CSS!
 
 ## Configuration
-Conductor can be configured using a [yaml](https://en.wikipedia.org/wiki/YAML) file. By default, Conductor looks for a "config.yaml" at the root of embedded resources.
+Conductor can be configured using a [yaml](https://en.wikipedia.org/wiki/YAML) file. By default, Conductor looks for a `config.yaml` at the root of embedded resources.
 
 The file has 3 sections: `current configuration`, `defaults`, and `schemes`.
 
@@ -86,6 +86,36 @@ shorter_timeouts:
   retries: 2
 ```
 You can see a variety of example configuration files in the unit tests for conductor [here](src/test/resources/test_yaml)
+
+## Config Annotation
+Test classes can be annotated with `@Config` to add override the default browser or assign a `path` that will be appended to the default `baseUrl`.
+
+```@java
+@Config(
+    path = "/ideas",
+    browser = Browser.CHROME
+)
+public class IdeasTest extends BaseTest {
+    
+}
+```
+
+## JVM Environment Arguments
+Conductor supports a couple of jvm env args that can be passed in to override some defaults:
+- `conductorCurrentSchemes` to override the default `currentSchemes` 
+- `conductorBaseUrl` to override the default `baseUrl` (including ones specified on **current schemes!**)
+  - This is specifically helpful when dealing with a dynamic url (e.g. Pull Request build with a unique build number).
+
+```
+mvn test -DconductorCurrentSchemes=shorter_timeouts,stage-dev
+```
+```
+mvn test -DconductorBaseUrl=https://wta-stage-dev-pr-759.herokuapp.com
+```
+
+# Methods
+Supported methods can be separated by functionality into Actions, In-line validations, and helper methods for switching between windows and frames (listed below in more detail). 
+- For a full list of the supported APIs see the [Conductor.java](src/main/java/io/ddavison/conductor/Conductor.java) interface.  
 
 ## Actions
 You can perform any action that you could possibly do, using the inline actions.

--- a/src/main/java/io/ddavison/conductor/ConductorConfig.java
+++ b/src/main/java/io/ddavison/conductor/ConductorConfig.java
@@ -21,6 +21,8 @@ public class ConductorConfig {
     // JVM env args
     static final String CONDUCTOR_CURRENT_SCHEMES = "conductorCurrentSchemes";
     static final String CONDUCTOR_BASE_URL = "conductorBaseUrl";
+    @Deprecated
+    static final String CONDUCTOR_BASE_URL_OLD = "CONDUCTOR_BASE_URL";
 
     // YAML Keys
     private static final String DEFAULTS = "defaults";
@@ -105,7 +107,7 @@ public class ConductorConfig {
         }
 
         // Override base url from env var
-        String baseUrl = System.getProperty(CONDUCTOR_BASE_URL);
+        String baseUrl = System.getProperty(CONDUCTOR_BASE_URL, System.getProperty(CONDUCTOR_BASE_URL_OLD, null));
         if (baseUrl != null) {
             setBaseUrl(baseUrl);
         }


### PR DESCRIPTION
- Added old `-DCONDUCTOR_BASE_URL` env arg support so it won't break TeamCity CI builds
  - Tagged it as `@Deprecated`
- Updated `README.md` to include the `@Config` annotation, JVM Env Args, and a link to all the `Conductor` APIs.