### PR TITLE
Hotfix for browsers not closing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <name>conductor</name>
   <url>http://github.com/willowtreeapps/conductor</url>
-  <version>3.2.1</version>
+  <version>3.2.2</version>
   <description>A quick and easy start-up browser automation framework based on Selenium WebDriver</description>
 
     <parent>

--- a/src/main/java/io/ddavison/conductor/listeners/TestListener.java
+++ b/src/main/java/io/ddavison/conductor/listeners/TestListener.java
@@ -34,15 +34,15 @@ public class TestListener implements ITestListener {
 
     @Override
     public void onTestSkipped(ITestResult iTestResult) {
-        if (driver != null) {
-            driver.quit();
+        if (iTestResult.getInstance() instanceof Locomotive) {
+            ((Locomotive) iTestResult.getInstance()).quit();
         }
     }
 
     @Override
     public void onTestFailedButWithinSuccessPercentage(ITestResult iTestResult) {
-        if (driver != null) {
-            driver.quit();
+        if (iTestResult.getInstance() instanceof Locomotive) {
+            ((Locomotive) iTestResult.getInstance()).quit();
         }
     }
 


### PR DESCRIPTION
If test failed before `@onTestStart` got called (e.g. on a constructor, `@BeforeTest`, `@BeforeSuite`, etc.) the browser would still remain open, this should fix that scenario.