### PR TITLE
Feature/soft-asserts to Conductor

### DIFF
--- a/src/main/java/io/ddavison/conductor/Conductor.java
+++ b/src/main/java/io/ddavison/conductor/Conductor.java
@@ -194,6 +194,15 @@ public interface Conductor<Test> {
         Validations
      */
     /**
+     * When an assertion fails, don't throw an exception but record the failure.
+     * Calling {@code assertAll()} will cause an exception to be thrown if at
+     * least one assertion failed.
+     */
+    Test softAssert(String css);
+    Test softAssert(By by);
+    Test softAssert(String css, String text);
+    Test softAssert(By by, String text);
+    /**
      * Validates that an element is present.
      * @param css/by The element
      * @return The implementing class for fluency

--- a/src/main/java/io/ddavison/conductor/Conductor.java
+++ b/src/main/java/io/ddavison/conductor/Conductor.java
@@ -200,8 +200,8 @@ public interface Conductor<Test> {
      */
     Test softAssert(String css);
     Test softAssert(By by);
-    Test softAssert(String css, String text);
-    Test softAssert(By by, String text);
+    Test assertAll();
+
     /**
      * Validates that an element is present.
      * @param css/by The element

--- a/src/main/java/io/ddavison/conductor/Locomotive.java
+++ b/src/main/java/io/ddavison/conductor/Locomotive.java
@@ -19,6 +19,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.pmw.tinylog.Logger;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
+import org.testng.asserts.SoftAssert;
 
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +38,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
     private int attempts = 0;
     private Actions actions;
     private Map<String, String> vars = new HashMap<>();
+    private SoftAssert softAssert = new SoftAssert();
 
     private Pattern p;
     private Matcher m;
@@ -538,6 +540,43 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
     /* ************************ */
 
     /* Validation Functions for Testing */
+
+    /**
+     *
+     */
+    // Could change name to softAssertEquals for clarity?
+    public Locomotive softAssert(String css, String text) {
+        return softAssert(By.cssSelector(css), text);
+    }
+    /**
+     * @param by is the selector
+     * @param text is what the selector should be equal to
+     *
+     */
+    // Could change name of this method to softAssertEquals for clarity?
+    public Locomotive softAssert(By by, String text) {
+        waitForElement(by);
+        softAssert.assertEquals(by, text);
+        return this;
+    }
+    // Could change name of this method to softAssertTrue for clarity?
+    public Locomotive softAssert(String css) {
+        return softAssert(By.cssSelector(css));
+    }
+    /**
+     * @param by is the selector/accessibility id
+     *
+     */
+    // Could change name of this method to softAssertTrue for clarity?
+    public Locomotive softAssert(By by) {
+        waitForElement(by);
+        softAssert.assertTrue(isPresent(by));
+        return this;
+    }
+    public Locomotive assertAll() {
+        softAssert.assertAll();
+        return this;
+    }
 
     public Locomotive validatePresent(String css) {
         return validatePresent(By.cssSelector(css));

--- a/src/main/java/io/ddavison/conductor/Locomotive.java
+++ b/src/main/java/io/ddavison/conductor/Locomotive.java
@@ -540,36 +540,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
     /* ************************ */
 
     /* Validation Functions for Testing */
-
-    /**
-     *
-     */
-    // Could change name to softAssertEquals for clarity?
-    public Locomotive softAssert(String css, String text) {
-        return softAssert(By.cssSelector(css), text);
-    }
-    /**
-     * @param by is the selector
-     * @param text is what the selector should be equal to
-     *
-     */
-    // Could change name of this method to softAssertEquals for clarity?
-    public Locomotive softAssert(By by, String text) {
-        waitForElement(by);
-        softAssert.assertEquals(by, text);
-        return this;
-    }
-    // Could change name of this method to softAssertTrue for clarity?
     public Locomotive softAssert(String css) {
         return softAssert(By.cssSelector(css));
     }
+
     /**
+     * SoftAssert version of validatePresent()
      * @param by is the selector/accessibility id
-     *
      */
-    // Could change name of this method to softAssertTrue for clarity?
     public Locomotive softAssert(By by) {
-        waitForElement(by);
         softAssert.assertTrue(isPresent(by));
         return this;
     }

--- a/src/test/java/io/ddavison/conductor/FrameworkTest.java
+++ b/src/test/java/io/ddavison/conductor/FrameworkTest.java
@@ -142,4 +142,31 @@ public class FrameworkTest extends Locomotive {
         assertThat(isInView(newTabLink)).isTrue();
     }
 
+    /**
+     * Testing softAssert validatePresent (This test is supposed to fail after assertAll)
+     */
+    @Test
+    public void testSoftAssertValidateShouldFail() {
+        softAssert(By.cssSelector("#click"))
+                .softAssert(By.cssSelector("#setTextField"))
+                .softAssert(By.cssSelector("#textArea"))
+                .softAssert(By.cssSelector("#select"))
+                .softAssert(By.cssSelector("#shouldFailTest"));
+        System.out.println("Verify that test keep running after softAssert Fails to make sure softAssert is working as intended");
+        assertAll();
+    }
+
+    /**
+     * Testing softAssert validatePresent (This test is supposed to pass after assertAll)
+     */
+    @Test
+    public void testSoftAssertValidate() {
+        softAssert(By.cssSelector("#click"))
+                .softAssert(By.cssSelector("#setTextField"))
+                .softAssert(By.cssSelector("#textArea"))
+                .softAssert(By.cssSelector("#select"));
+        assertAll();
+    }
+
+
 }


### PR DESCRIPTION
The point of this feature is to make it easier to use SoftAssert using Conductor.

This feature only adds 2 methods:
1) SoftAssert version of ValidatePresent
2) AssertAll

Goals:
1) Eliminate need to create SoftAssert object
2) Allow chaining of SoftAssert methods

Todo in next PR:
1) Add more methods within SoftAssert, such as AssertEquals... which I was having trouble with
2) Experiment with maybe just adding a softAssert variable to interface? Probably not ideal and can't chain methods using this approach as far as I know
