### PR TITLE
updates to webdrivermanager version and tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>1.7.2</version>
+            <version>3.3.0</version>
         </dependency>
 
         <dependency>
@@ -213,17 +213,11 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.19</version>
         </dependency>
+
         <dependency> <!-- Required for webdrivermanager logging -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.0.2</version>
-        </dependency>
-
-        <!-- Download latest drivers -->
-        <dependency>
-            <groupId>io.github.bonigarcia</groupId>
-            <artifactId>webdrivermanager</artifactId>
-            <version>1.7.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/ddavison/conductor/Locomotive.java
+++ b/src/main/java/io/ddavison/conductor/Locomotive.java
@@ -395,9 +395,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
 
     public Locomotive waitForWindow(String regex) {
         Set<String> windows = getDriver().getWindowHandles();
-
         for (String window : windows) {
             try {
+                // Wait before switching tabs so that the new tab can load; else it loads a blank page
+                try {
+                Thread.sleep(100);
+                } catch (Exception x) {
+                    Logger.error(x);
+                }
+
                 getDriver().switchTo().window(window);
 
                 p = Pattern.compile(regex);

--- a/src/main/java/io/ddavison/conductor/util/DriverUtil.java
+++ b/src/main/java/io/ddavison/conductor/util/DriverUtil.java
@@ -1,10 +1,7 @@
 package io.ddavison.conductor.util;
 
 import io.ddavison.conductor.ConductorConfig;
-import io.github.bonigarcia.wdm.ChromeDriverManager;
-import io.github.bonigarcia.wdm.EdgeDriverManager;
-import io.github.bonigarcia.wdm.FirefoxDriverManager;
-import io.github.bonigarcia.wdm.InternetExplorerDriverManager;
+import io.github.bonigarcia.wdm.*;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
@@ -34,7 +31,7 @@ public class DriverUtil {
                     ChromeOptions chromeOptions = new ChromeOptions()
                             .merge(buildCustomCapabilities(config, desiredCapabilities));
                     if (isLocal) {
-                        ChromeDriverManager.getInstance().setup();
+                        WebDriverManager.chromedriver().setup();
                         driver = new ChromeDriver(chromeOptions);
                     } else {
                         capabilities = chromeOptions;
@@ -44,7 +41,7 @@ public class DriverUtil {
                     FirefoxOptions firefoxOptions = new FirefoxOptions()
                             .merge(buildCustomCapabilities(config, desiredCapabilities));
                     if (isLocal) {
-                        FirefoxDriverManager.getInstance().setup();
+                        WebDriverManager.firefoxdriver().setup();
                         driver = new FirefoxDriver(firefoxOptions);
                     } else {
                         capabilities = firefoxOptions;
@@ -54,7 +51,7 @@ public class DriverUtil {
                     InternetExplorerOptions internetExplorerOptions = new InternetExplorerOptions()
                             .merge(buildCustomCapabilities(config, desiredCapabilities));
                     if (isLocal) {
-                        InternetExplorerDriverManager.getInstance().setup();
+                        WebDriverManager.iedriver().setup();
                         driver = new InternetExplorerDriver(internetExplorerOptions);
                     } else {
                         capabilities = internetExplorerOptions;
@@ -64,7 +61,7 @@ public class DriverUtil {
                     EdgeOptions edgeOptions = new EdgeOptions()
                             .merge(buildCustomCapabilities(config, desiredCapabilities));
                     if (isLocal) {
-                        EdgeDriverManager.getInstance().setup();
+                        WebDriverManager.edgedriver().setup();
                         driver = new EdgeDriver(edgeOptions);
                     } else {
                         capabilities = edgeOptions;


### PR DESCRIPTION
- Updated webdrivermanager version to 3.3.0 from 1.7.2
-- Updated tests to support the new version
-- Removed a duplicate maven dependency for webdrivermanager
- Added in a short sleep in the waitForWindow function to fix failures in testWindowSwitching (it would open a new tab and the text would be in the address bar, but the page would be blank). I couldn't find a better way to address this.